### PR TITLE
Filter only existing file, take the first 3 opened

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -91,12 +91,8 @@ export function activate(context: vscode.ExtensionContext) {
 			window.showErrorMessage("Meld Diff:\nCan't diff: Only one file is visible in editor!")
 			return;
 		}
-		if (open_files.length > 3) {
-			window.showErrorMessage("Meld Diff:\nCan't diff: More than three files are visible in editor!")
-			return;
-		}
 
-		cp.exec('meld ' + open_files.join(" "), (error: Error) => {
+		cp.exec('meld ' + open_files.filter(v => existsSync(v)).slice(0,3).join(" "), (error: Error) => {
 			if (error) {
 				if (error.message.match(/meld: not found/)) {
 					window.showErrorMessage("Meld Diff: meld is not installed!");


### PR DESCRIPTION
Compare visible command would include non-file windows (such as output) in meld command. 
To fix filter the list to include only existing files.
Also instead of bailing out on more then 3 files opened just take the first 3.